### PR TITLE
[KIECLOUD-233] sanitize error and show error in Expandable

### DIFF
--- a/cmd/testwebapp.go
+++ b/cmd/testwebapp.go
@@ -34,7 +34,20 @@ func main() {
 func callback(yamlString string) error {
 	logrus.Infof("Mock deploy yaml:\n%s", yamlString)
 	if strings.Contains(yamlString, "fail-test") {
-		return fmt.Errorf("Failing on purpose")
+		errorMsg := `KieApp.app.kiegroup.org "fail-test" is invalid: []: Invalid value: map[string]interface {}{"status":map[string]interface {}
+		{"deployments":map[string]interface {}{}, "conditions":interface {}(nil)}, "kind":"KieApp", "apiVersion":"app.kiegroup.org/v1",
+		"metadata":map[string]interface {}{"namespace":"operator-ui", "generation":1, "uid":"29bc40ec-8388-11e9-9eb6-06daf81fbd22",
+			"name":"fail-test", "creationTimestamp":"2019-05-31T09:40:45Z"}, "spec":map[string]interface {}{"auth":map[string]interface {}{},
+			"upgrades":map[string]interface {}{}, "environment":"rhpam-trial", "imageRegistry":map[string]interface {}{"insecure":false},
+			"objects":map[string]interface {}{"console":map[string]interface {}{"resources":map[string]interface {}{}},
+			"servers":[]interface {}{map[string]interface {}{"build":map[string]interface {}{"gitSource":map[string]interface {}{},
+			"webhooks":[]interface {}{map[string]interface {}{"type":"GitHub", "secret":"testsecret"}}}, "resources":map[string]interface {}{}}}},
+			"commonConfig":map[string]interface {}{}}}: validation failure list:
+			spec.objects.servers.build.gitSource.uri in body is required
+			spec.objects.servers.build.gitSource.reference in body is required
+			spec.objects.servers.build.kieServerContainerDeployment in body is required`
+		logrus.Errorf("Return a canned error: %v", errorMsg)
+		return fmt.Errorf(errorMsg)
 	}
 	return nil
 }

--- a/frontend/src/component/operator-wizard/page-component/ReviewPage.js
+++ b/frontend/src/component/operator-wizard/page-component/ReviewPage.js
@@ -9,13 +9,22 @@ import {
   EmptyState,
   EmptyStateVariant,
   EmptyStateIcon,
-  EmptyStateBody
+  EmptyStateBody,
+  Expandable
 } from "@patternfly/react-core";
 import { CheckCircleIcon, ErrorCircleOIcon } from "@patternfly/react-icons";
 
 export default class ReviewPage extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      showErrorMsg: false
+    };
+    this.onShowErrorMsg = () => {
+      this.setState({
+        showErrorMsg: !this.state.showErrorMsg
+      });
+    };
   }
 
   render() {
@@ -33,13 +42,24 @@ export default class ReviewPage extends React.Component {
           </EmptyState>
         );
       } else {
+        const { showErrorMsg } = this.state;
         return (
           <EmptyState variant={EmptyStateVariant.full}>
             <EmptyStateIcon icon={ErrorCircleOIcon} />
             <Title headingLevel="h5" size="lg">
               Unable to deploy the application
             </Title>
-            <EmptyStateBody>{this.props.deployment.error}</EmptyStateBody>
+            <Expandable
+              toggleText={showErrorMsg ? "Hide details" : "Show details"}
+              onToggle={this.onShowErrorMsg}
+              isExpanded={showErrorMsg}
+            >
+              <TextContent>
+                <Text component={TextVariants.small}>
+                  {this.props.deployment.error}
+                </Text>
+              </TextContent>
+            </Expandable>
           </EmptyState>
         );
       }

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -55,6 +55,12 @@ func RunWebServer(config Configuration) error {
 		}
 	}
 
+	sanitizeError := func(err error) string {
+		errorMsg := strings.ReplaceAll(fmt.Sprint(err), "\"", "\\\"")
+		errorMsg = strings.ReplaceAll(errorMsg, "\n", " ")
+		return strings.ReplaceAll(errorMsg, "\t", "")
+	}
+
 	processYaml := func(writer http.ResponseWriter, reader *http.Request) {
 		body, err := ioutil.ReadAll(reader.Body)
 		if err != nil {
@@ -83,7 +89,7 @@ func RunWebServer(config Configuration) error {
 			if err != nil {
 				logrus.Errorf("Error processing the request %v", err)
 				writer.WriteHeader(http.StatusBadRequest)
-				writer.Write([]byte(fmt.Sprintf("{\"result\": \"error\", \"message\": \"%v\"}", err)))
+				writer.Write([]byte(fmt.Sprintf("{\"result\": \"error\", \"message\": \"%v\"}", sanitizeError(err))))
 			} else {
 				writer.WriteHeader(http.StatusOK)
 				writer.Write([]byte("{\"result\": \"success\"}"))


### PR DESCRIPTION
Fix https://issues.jboss.org/browse/KIECLOUD-233

Need to sanitize server errors. Error messages can be displayed in the confirmation page using an Expandable.
Canned error added to the test backend

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>