### PR TITLE
[KIECLOUD-254] Allow default value for JNDI Name with external databases

### DIFF
--- a/test/examples/full-form.json
+++ b/test/examples/full-form.json
@@ -896,7 +896,6 @@
                             {
                               "label": "JNDI name",
                               "type": "text",
-                              "required": true,
                               "jsonPath": "$.spec.objects.servers[*].database.externalConfig.jndiName",
                               "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/ExampleDS.",
                               "default": "java:jboss/datasources/jbpmDS"


### PR DESCRIPTION
Fix https://issues.jboss.org/projects/KIECLOUD/issues/KIECLOUD-254

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>