### PR TITLE
[RHPAM-2490] - Replace roles configuration shown for internal authent…

### DIFF
--- a/test/examples/full-form.json
+++ b/test/examples/full-form.json
@@ -180,6 +180,13 @@
                   "type": "text",
                   "jsonPath": "$.spec.auth.roleMapper.rolesProperties",
                   "description": "When present, the RoleMapping Login Module will be configured to use the provided file. This property defines the fully-qualified file path and name of a properties file or resource which maps roles to replacement roles. The format is original_role=role1,role2,role3"
+                },
+                {
+                  "label": "Replace roles",
+                  "type": "checkbox",
+                  "jsonPath": "$.spec.auth.roleMapper.replaceRole",
+                  "default": "false",
+                  "description": "Whether to add to the current roles, or replace the current roles with the mapped ones. Replaces if set to true."
                 }
               ]
             },
@@ -352,6 +359,13 @@
                   "type": "text",
                   "jsonPath": "$.spec.auth.roleMapper.rolesProperties",
                   "description": "When present, the RoleMapping Login Module will be configured to use the provided file. This property defines the fully-qualified file path and name of a properties file or resource which maps roles to replacement roles. The format is original_role=role1,role2,role3"
+                },
+                {
+                  "label": "Replace roles",
+                  "type": "checkbox",
+                  "jsonPath": "$.spec.auth.roleMapper.replaceRole",
+                  "default": "false",
+                  "description": "Whether to add to the current roles, or replace the current roles with the mapped ones. Replaces if set to true."
                 }
               ]
             },
@@ -424,13 +438,6 @@
           "jsonPath": "$.spec",
           "visible": true,
           "fields": [
-            {
-              "label": "Replace roles",
-              "type": "checkbox",
-              "jsonPath": "$.spec.auth.roleMapper.replaceRole",
-              "default": "false",
-              "description": "Whether to add to the current roles, or replace the current roles with the mapped ones. Replaces if set to true."
-            },
             {
               "label": "Image tag",
               "type": "text",


### PR DESCRIPTION
Replace roles configuration shown for internal authentication and  should be available just for SSO or LDAP authentication.

Signed-off-by: Swati Kale <swkale@redhat.com>