### PR TITLE
[RHPAM-2522] - Provide usable way of setting extensions image name and namespace for external DB driver in Operator UI 

### DIFF
--- a/test/examples/full-form.json
+++ b/test/examples/full-form.json
@@ -1136,6 +1136,50 @@
                           "visible": false,
                           "fields": [
                             {
+                              "label": "Enable Extension image stream",
+                              "type": "checkbox",
+                              "required": false,
+                              "description": "When set to true will configure the KIE Server with Extension Image Stream.",
+                              "jsonPath": "$.spec.objects.servers[*].build",
+                              "originalJsonPath": "$.spec.objects.servers[*].build",
+                              "fields": [
+                                {
+                                  "label": "Enable Extension image stream",
+                                  "type": "fieldGroup",
+                                  "jsonPath": "$.spec.objects.servers[*].build",
+                                  "originalJsonPath": "$.spec.objects.servers[*].build",
+                                  "displayWhen": "true",
+                                  "visible": false,
+                                  "fields": [
+                                    {
+                                      "label": "Extension image stream tag",
+                                      "type": "text",
+                                      "required": true,
+                                      "jsonPath": "$.spec.objects.servers[*].build.extensionImageStreamTag",
+                                      "description": "ImageStreamTag definition for the image containing the drivers and configuration. For example, custom-driver-image:7.7.0.",
+                                      "default": "rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.5.0-SNAPSHOT"
+                                    },
+                                    {
+                                      "label": "Extension image stream tag namespace",
+                                      "type": "text",
+                                      "required": false,
+                                      "jsonPath": "$.spec.objects.servers[*].build.extensionImageStreamTagNamespace",
+                                      "description": "Namespace within which the ImageStream definition for the image containing the drivers and configuration is located. Defaults to openshift namespace.",
+                                      "default": "rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.5.0-SNAPSHOT"
+                                    },
+                                    {
+                                      "label": "Extension image install Dir",
+                                      "type": "text",
+                                      "required": false,
+                                      "jsonPath": "$.spec.objects.servers[*].build.extensionImageInstallDir",
+                                      "description": "scription: Full path to the directory within the extensions image where the extensions are located (e.g. install.sh, modules/, etc. Do not change this field unless you have sure about the changes that you is doing).",
+                                      "default": "rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.5.0-SNAPSHOT"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
                               "label": "Driver",
                               "type": "text",
                               "required": true,

--- a/test/examples/full-schema.json
+++ b/test/examples/full-schema.json
@@ -384,8 +384,30 @@
                     "description":
                       "Configuration of build configs for immutable KIE servers",
                     "type": "object",
-                    "required": ["kieServerContainerDeployment", "gitSource"],
+                    "oneOf": [
+                      {
+                        "required": ["extensionImageStreamTag"]
+                      },
+                      {
+                        "required": [
+                          "kieServerContainerDeployment",
+                          "gitSource"
+                        ]
+                      }
+                    ],
                     "properties": {
+                      "extensionImageStreamTag": {
+                        "type": "string",
+                        "description": "ImageStreamTag definition for the image containing the drivers and configuration. For example, custom-driver-image:7.7.0."
+                      },
+                      "extensionImageStreamTagNamespace": {
+                        "type": "string",
+                        "description": "Namespace within which the ImageStream definition for the image containing the drivers and configuration is located. Defaults to openshift namespace."
+                      },
+                      "extensionImageInstallDir": {
+                        "type": "string",
+                        "description": "Full path to the directory within the extensions image where the extensions are located (e.g. install.sh, modules/, etc. Do not change this field unless you have sure about the changes that you is doing)."
+                      },
                       "artifactDir": {
                         "description":
                           "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",


### PR DESCRIPTION
updated the UI w.r.t changes against RHPAM-2533 (build config changes in Operator for extensions image settings)

Signed-off-by: Swati Kale <swkale@redhat.com>